### PR TITLE
[ML-9631] Convert Spark DataFrame into TensorFlow dataset via petastorm without lazy loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 .idea
 .pytest_cache
+*.DS_Store
 
 # Repository build artifacts
 petastorm.egg-info

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -23,16 +23,56 @@ type_map = {
 }
 
 
-def save_df_as_parquet(df: DataFrame, dir_path: str) -> str:
+class tf_dataset_context_manager:
+
+    def __init__(self, converter):
+        self.converter = converter
+
+    def __enter__(self) -> tf.data.Dataset:
+        return self.converter.dataset
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.converter.close()
+
+
+class SparkDatasetConverter:
     """
-    Save a SparkDataFrame in parquet format in dbfs (Liang: during dev: the local file system).
+    The SparkDatasetConverter class manages the intermediate files when converting a SparkDataFrame to a
+    Tensorflow Dataset or PyTorch DataLoader.
+    """
+    def __init__(self, cache_file_path):
+        """
+        :param cache_file_path: The path to store the cache files.
+        """
+        self.cache_file_path = cache_file_path
+        self.dataset = None
+
+    def make_tf_dataset(self) -> tf_dataset_context_manager:
+        reader = make_batch_reader("file://" + self.cache_file_path)
+        self.dataset = make_petastorm_dataset(reader)
+        return tf_dataset_context_manager(self)
+
+    def close(self):
+        """
+        Todo: delete cache files
+        :return:
+        """
+        pass
+
+
+def _cache_df_or_retrieve_cache_path(df: DataFrame, dir_path: str) -> str:
+    """
+    Check whether the df is cached.
+    If so, return the existing cache file path.
+    If not, cache the df into the configured cache dir in parquet format and return the cache file path.
     :param df: SparkDataFrame
     :param dir_path: the directory for the saved parquet file, could be local, hdfs, dbfs, ...
     :return: the path of the saved parquet file
     """
+    # Todo: add cache management
     df.write.mode("overwrite") \
-      .option("parquet.block.size", 1024 * 1024) \
-      .parquet(CACHE_DIR)
+        .option("parquet.block.size", 1024 * 1024) \
+        .parquet(CACHE_DIR)
 
     # remove _xxx files, which will break `pyarrow.parquet` loading
     underscore_files = [f for f in os.listdir(dir_path) if f.startswith("_")]
@@ -41,10 +81,14 @@ def save_df_as_parquet(df: DataFrame, dir_path: str) -> str:
     return CACHE_DIR
 
 
-def spark_df_to_tf_dataset(df: DataFrame) -> tf.data.Dataset:
-    # save as parquet
-    saved_path = save_df_as_parquet(df, CACHE_DIR)
-    # load parquet into petastorm reader
-    reader = make_batch_reader("file://"+saved_path)
-    dataset = make_petastorm_dataset(reader)
-    return dataset
+def make_spark_converter(df: DataFrame) -> SparkDatasetConverter:
+    """
+    This class will check whether the df is cached.
+    If so, it will use the existing cache file path to construct a SparkDatasetConverter.
+    If not, Materialize the df into the configured cache dir in parquet format and use the cache file path to
+    construct a SparkDatasetConverter.
+    :param df: The DataFrame to materialize.
+    :return: a SparkDatasetConverter
+    """
+    cache_file_path = _cache_df_or_retrieve_cache_path(df, CACHE_DIR)
+    return SparkDatasetConverter(cache_file_path)

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -1,0 +1,50 @@
+from petastorm import make_batch_reader
+from petastorm.tf_utils import make_petastorm_dataset
+from pyspark.sql.dataframe import DataFrame
+
+import numpy as np
+import os
+import tensorflow as tf
+
+assert(tf.version.VERSION == '1.15.0')
+
+# Config
+CACHE_DIR = "/tmp/tf"
+
+# primitive type mapping
+type_map = {
+    "boolean": np.bool_,
+    "byte": np.int8,  # 8-bit signed
+    "double": np.float64,
+    "float": np.float32,
+    "integer": np.int32,
+    "long": np.int64,
+    "short": np.int16
+}
+
+
+def save_df_as_parquet(df: DataFrame, dir_path: str) -> str:
+    """
+    Save a SparkDataFrame in parquet format in dbfs (Liang: during dev: the local file system).
+    :param df: SparkDataFrame
+    :param dir_path: the directory for the saved parquet file, could be local, hdfs, dbfs, ...
+    :return: the path of the saved parquet file
+    """
+    df.write.mode("overwrite") \
+      .option("parquet.block.size", 1024 * 1024) \
+      .parquet(CACHE_DIR)
+
+    # remove _xxx files, which will break `pyarrow.parquet` loading
+    underscore_files = [f for f in os.listdir(dir_path) if f.startswith("_")]
+    for f in underscore_files:
+        os.remove(os.path.join(dir_path, f))
+    return CACHE_DIR
+
+
+def spark_df_to_tf_dataset(df: DataFrame) -> tf.data.Dataset:
+    # save as parquet
+    saved_path = save_df_as_parquet(df, CACHE_DIR)
+    # load parquet into petastorm reader
+    reader = make_batch_reader("file://"+saved_path)
+    dataset = make_petastorm_dataset(reader)
+    return dataset

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -1,0 +1,62 @@
+#
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from pyspark.sql import SparkSession
+from pyspark.sql.types import StructType, StructField, \
+    BooleanType, FloatType, ShortType, IntegerType, LongType, DoubleType
+
+from petastorm.spark.spark_dataset_converter import spark_df_to_tf_dataset
+
+import tensorflow as tf
+import numpy as np
+import unittest
+
+
+class TfConverterTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.spark = SparkSession.builder \
+            .master("local[2]") \
+            .appName("petastorm.spark tests") \
+            .getOrCreate()
+
+    def test_primitive(self):
+        # test primitive columns
+        schema = StructType([
+            StructField("bool_col", BooleanType(), False),
+            StructField("float_col", FloatType(), False),
+            StructField("double_col", DoubleType(), False),
+            StructField("short_col", ShortType(), False),
+            StructField("int_col", IntegerType(), False),
+            StructField("long_col", LongType(), False)
+        ])
+        df = self.spark.createDataFrame([
+            (True, 0.12, 432.1, 5, 5, 0),
+            (False, 123.45, 0.987, 9, 908, 765)],
+            schema=schema)
+
+        dataset = spark_df_to_tf_dataset(df)
+
+        iterator = dataset.make_one_shot_iterator()
+        tensor = iterator.get_next()
+        with tf.Session() as sess:
+            ts = sess.run(tensor)
+
+        assert (ts.bool_col.dtype.type == np.bool_)
+        assert (ts.float_col.dtype.type == np.float32)
+        assert (ts.double_col.dtype.type == np.float64)
+        assert (ts.short_col.dtype.type == np.int16)
+        assert (ts.int_col.dtype.type == np.int32)
+        assert (ts.long_col.dtype.type == np.int64)

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -1,18 +1,3 @@
-#
-# Copyright 2017 Databricks, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 from pyspark.sql import SparkSession
 from pyspark.sql.types import StructType, StructField, \
     BooleanType, FloatType, ShortType, IntegerType, LongType, DoubleType

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -2,7 +2,7 @@ from pyspark.sql import SparkSession
 from pyspark.sql.types import StructType, StructField, \
     BooleanType, FloatType, ShortType, IntegerType, LongType, DoubleType
 
-from petastorm.spark.spark_dataset_converter import spark_df_to_tf_dataset
+from petastorm.spark.spark_dataset_converter import make_spark_converter
 
 import tensorflow as tf
 import numpy as np
@@ -32,12 +32,12 @@ class TfConverterTest(unittest.TestCase):
             (False, 123.45, 0.987, 9, 908, 765)],
             schema=schema)
 
-        dataset = spark_df_to_tf_dataset(df)
-
-        iterator = dataset.make_one_shot_iterator()
-        tensor = iterator.get_next()
-        with tf.Session() as sess:
-            ts = sess.run(tensor)
+        converter = make_spark_converter(df)
+        with converter.make_tf_dataset() as dataset:
+            iterator = dataset.make_one_shot_iterator()
+            tensor = iterator.get_next()
+            with tf.Session() as sess:
+                ts = sess.run(tensor)
 
         assert (ts.bool_col.dtype.type == np.bool_)
         assert (ts.float_col.dtype.type == np.float32)


### PR DESCRIPTION
### What changes are proposed in this PR?

This PR implements a simple data converter that converts a spark dataframe to a `tensorflow.data.Dataset`.
This data converter is compatible with tensorflow 1.15.
1. It supports primitive type columns:
```
type_map = {
    "boolean": np.bool_,
    "byte": np.int8,  # 8-bit signed
    "double": np.float64,
    "float": np.float32,
    "integer": np.int32,
    "long": np.int64,
    "short": np.int16
}
```
It does not support vector type columns, BinaryType, ArrayType, StringType, which will be introduced in following PRs.
It is not designed to support DateType, DecimalType, MapType, NullType, TimestampType.

2. It caches all the dataframes to the same fixed path `CACHE_DIR`, and overwrites the folder every time. Cache management will be added in following PRs.
3. It loads the dataset eagerly in the local process. Distributed dataset will be added in following PRs.

### Why these changes are needed?
This PR is a starting point for the feature designed in `[ML-9240] Simplify data conversion from Spark to TensorFlow/PyTorch`.

### How is this feature tested?
Unit tests.

[ML-9240]: https://databricks.atlassian.net/browse/ML-9240