### PR TITLE
[ML-9741] Use atexit handler to delete cached folder

### DIFF
--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from petastorm.spark.spark_dataset_converter import make_spark_converter, SparkDatasetConverter
 from pyspark.sql import SparkSession
 from pyspark.sql.types import StructType, StructField, \
@@ -5,6 +6,7 @@ from pyspark.sql.types import StructType, StructField, \
 
 import numpy as np
 import os
+import subprocess
 import tensorflow as tf
 import unittest
 
@@ -42,21 +44,21 @@ class TfConverterTest(unittest.TestCase):
                 # Now we only have one batch.
             for i in range(converter.dataset_size):
                 for col in df.schema.names:
-                    self.assertEquals(getattr(ts, col)[i], expected_df[i][col])
+                    self.assertEqual(getattr(ts, col)[i], expected_df[i][col])
 
-            self.assertEquals(len(converter), len(expected_df))
+            self.assertEqual(len(converter), len(expected_df))
 
-        self.assertEquals(ts.bool_col.dtype.type, np.bool_, "Boolean type column is not inferred correctly.")
-        self.assertEquals(ts.float_col.dtype.type, np.float32, "Float type column is not inferred correctly.")
-        self.assertEquals(ts.double_col.dtype.type, np.float64, "Double type column is not inferred correctly.")
-        self.assertEquals(ts.short_col.dtype.type, np.int16, "Short type column is not inferred correctly.")
-        self.assertEquals(ts.int_col.dtype.type, np.int32, "Integer type column is not inferred correctly.")
-        self.assertEquals(ts.long_col.dtype.type, np.int64, "Long type column is not inferred correctly.")
+        self.assertEqual(ts.bool_col.dtype.type, np.bool_, "Boolean type column is not inferred correctly.")
+        self.assertEqual(ts.float_col.dtype.type, np.float32, "Float type column is not inferred correctly.")
+        self.assertEqual(ts.double_col.dtype.type, np.float64, "Double type column is not inferred correctly.")
+        self.assertEqual(ts.short_col.dtype.type, np.int16, "Short type column is not inferred correctly.")
+        self.assertEqual(ts.int_col.dtype.type, np.int32, "Integer type column is not inferred correctly.")
+        self.assertEqual(ts.long_col.dtype.type, np.int64, "Long type column is not inferred correctly.")
 
     def test_delete(self):
         test_path = "/tmp/petastorm_test"
-        os.mkdir(test_path)
-        os.mkdir(os.path.join(test_path, "dir1"))
+        Path(test_path).mkdir(parents=True, exist_ok=True)
+        Path(os.path.join(test_path, "dir1")).mkdir(parents=True, exist_ok=True)
         with open(os.path.join(test_path, "file1"), "w") as f:
             f.write("abc")
         with open(os.path.join(test_path, "file2"), "w") as f:
@@ -64,3 +66,26 @@ class TfConverterTest(unittest.TestCase):
         converter = SparkDatasetConverter(test_path, 0)
         converter.delete()
         self.assertFalse(os.path.exists(test_path))
+
+    def test_atexit(self):
+        cache_dir = "/tmp/123"
+        Path(cache_dir).mkdir(parents=True, exist_ok=True)
+        lines = """
+            from petastorm.spark.spark_dataset_converter import make_spark_converter
+            from pyspark.sql import SparkSession
+            import os
+            spark = SparkSession.builder.getOrCreate()
+            df = spark.createDataFrame([(1, 2),(4, 5)], ["col1", "col2"])
+            converter = make_spark_converter(df, '/tmp/123')
+            assert(os.path.exists(converter.cache_file_path))
+            f = open("/tmp/123/output", "w")
+            f.write(converter.cache_file_path)
+            f.close()
+            """
+        code_str = "; ".join(line.strip() for line in lines.strip().splitlines())
+        self.assertTrue(os.path.exists(cache_dir))
+        ret_code = subprocess.call(["python", "-c", code_str])
+        self.assertEqual(ret_code, 0)
+        with open(os.path.join(cache_dir, "output")) as f:
+            cache_file_path = f.read()
+        self.assertFalse(os.path.exists(cache_file_path))


### PR DESCRIPTION
### What changes are proposed in this PR?
When `make_spark_converter(...)` in a python process write a df cache into a folder, a delete function is registered to the `atexit` handler to delete the folder. When the python process exits (normally with SIGTERM), the cache written by this process would be deleted.

### Why it is needed?
To protect data security.

### How is this PR tested?
Unit test.

### User-facing API changes?
No.

Note: This PR include the changes in #2, when #2 is merged to master, this PR would include minimum changes.