### PR TITLE
[ML-9890] Add tests for all primitive types

### DIFF
--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -1,7 +1,7 @@
 from petastorm.spark.spark_dataset_converter import make_spark_converter, SparkDatasetConverter
 from pyspark.sql import SparkSession
 from pyspark.sql.types import StructType, StructField, \
-    BooleanType, FloatType, ShortType, IntegerType, LongType, DoubleType
+    BooleanType, FloatType, ShortType, IntegerType, LongType, DoubleType, StringType, BinaryType, ByteType
 
 import numpy as np
 import os
@@ -24,11 +24,15 @@ class TfConverterTest(unittest.TestCase):
             StructField("double_col", DoubleType(), False),
             StructField("short_col", ShortType(), False),
             StructField("int_col", IntegerType(), False),
-            StructField("long_col", LongType(), False)
+            StructField("long_col", LongType(), False),
+            StructField("str_col", StringType(), False),
+            StructField("bin_col", BinaryType(), False),
+            StructField("byte_col", ByteType(), False),
         ])
         df = self.spark.createDataFrame([
-            (True, 0.12, 432.1, 5, 5, 0),
-            (False, 123.45, 0.987, 9, 908, 765)], schema=schema).coalesce(1)
+            (True, 0.12, 432.1, 5, 5, 0, "hello", b"spark", -128),
+            (False, 123.45, 0.987, 9, 908, 765, "petastorm", b"12345", 127)], schema=schema)\
+            .coalesce(1)
         # If we use numPartition > 1, the order of the loaded dataset would be non-deterministic.
         expected_df = df.collect()
 
@@ -42,16 +46,24 @@ class TfConverterTest(unittest.TestCase):
                 # Now we only have one batch.
             for i in range(converter.dataset_size):
                 for col in df.schema.names:
-                    self.assertEquals(getattr(ts, col)[i], expected_df[i][col])
+                    actual_ele = getattr(ts, col)[i]
+                    expected_ele = expected_df[i][col]
+                    if type(actual_ele) == bytes:
+                        actual_ele = actual_ele.decode()
+                    if type(expected_ele) == bytearray:
+                        expected_ele = expected_ele.decode()
+                    self.assertEqual(actual_ele, expected_ele)
 
-            self.assertEquals(len(converter), len(expected_df))
+            self.assertEqual(len(converter), len(expected_df))
 
-        self.assertEquals(ts.bool_col.dtype.type, np.bool_, "Boolean type column is not inferred correctly.")
-        self.assertEquals(ts.float_col.dtype.type, np.float32, "Float type column is not inferred correctly.")
-        self.assertEquals(ts.double_col.dtype.type, np.float64, "Double type column is not inferred correctly.")
-        self.assertEquals(ts.short_col.dtype.type, np.int16, "Short type column is not inferred correctly.")
-        self.assertEquals(ts.int_col.dtype.type, np.int32, "Integer type column is not inferred correctly.")
-        self.assertEquals(ts.long_col.dtype.type, np.int64, "Long type column is not inferred correctly.")
+        self.assertEqual(ts.bool_col.dtype.type, np.bool_, "Boolean type column is not inferred correctly.")
+        self.assertEqual(ts.float_col.dtype.type, np.float32, "Float type column is not inferred correctly.")
+        self.assertEqual(ts.double_col.dtype.type, np.float64, "Double type column is not inferred correctly.")
+        self.assertEqual(ts.short_col.dtype.type, np.int16, "Short type column is not inferred correctly.")
+        self.assertEqual(ts.int_col.dtype.type, np.int32, "Integer type column is not inferred correctly.")
+        self.assertEqual(ts.long_col.dtype.type, np.int64, "Long type column is not inferred correctly.")
+        self.assertEqual(ts.str_col.dtype.type, np.object_, "String type column is not inferred correctly.")
+        self.assertEqual(ts.bin_col.dtype.type, np.object_, "Binary type column is not inferred correctly.")
 
     def test_delete(self):
         test_path = "/tmp/petastorm_test"

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -30,9 +30,9 @@ class TfConverterTest(unittest.TestCase):
             StructField("byte_col", ByteType(), False),
         ])
         df = self.spark.createDataFrame([
-            (True, 0.12, 432.1, 5, 5, 0, "hello", b"spark", -128),
-            (False, 123.45, 0.987, 9, 908, 765, "petastorm", b"12345", 127)], schema=schema)\
-            .coalesce(1)
+            (True, 0.12, 432.1, 5, 5, 0, "hello", bytearray(b"spark"), -128),
+            (False, 123.45, 0.987, 9, 908, 765, "petastorm", bytearray(b"12345"), 127)],
+            schema=schema).coalesce(1)
         # If we use numPartition > 1, the order of the loaded dataset would be non-deterministic.
         expected_df = df.collect()
 

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -31,9 +31,9 @@ class TfConverterTest(unittest.TestCase):
             StructField("bin_col", BinaryType(), False),
             StructField("byte_col", ByteType(), False),
         ])
-        df = self.spark.createDataFrame([
-            (True, 0.12, 432.1, 5, 5, 0, "hello", bytearray(b"spark"), -128),
-            (False, 123.45, 0.987, 9, 908, 765, "petastorm", bytearray(b"12345"), 127)],
+        df = self.spark.createDataFrame(
+            [(True, 0.12, 432.1, 5, 5, 0, "hello", bytearray(b"spark"), -128),
+             (False, 123.45, 0.987, 9, 908, 765, "petastorm", bytearray(b"12345"), 127)],
             schema=schema).coalesce(1)
         # If we use numPartition > 1, the order of the loaded dataset would be non-deterministic.
         expected_df = df.collect()


### PR DESCRIPTION

df: DataFrame | rows=df.collect() | Tensor (in Dataset) | Evaluated tensor dtype | Evaluated tensor element type
-- | -- | -- | -- | --
BooleanType | bool | bool | np.bool_ | bool_
ByteType | int | int8 | np.int8 | int8
ShortType | int | int16 | np.int16 | int16
IntegerType | int | int32 | np.int32 | int32
LongType | int | int64 | np.int64 | int64
FloatType | float | float32 | np.float32 | float32
DoubleType | float | float64 | np.float64 | float64
StringType | str | string | np.object_ | bytes
BinaryType | bytearray | string | np.object_ | bytes

### What changes are proposed in this PR?
Add tests for primitive types that petastorm supports. Added ByteType, StringType and BinaryType.
### Why these changes are needed?
These tests make it clear which column type is mapped to what types in the tensor.