### PR TITLE
[ML-9742] make_spark_converter() can reuse previously saved dataframe

### DIFF
--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -84,8 +84,8 @@ class CachedDataFrameMeta(object):
         self.data_path = None
 
     @classmethod
-    def create_cached_dataframe(df, parent_cache_dir, row_group_size, compression_codec):
-        meta = CachedDataFrameMeta(df, row_group_size, compression_codec)
+    def create_cached_dataframe(cls, df, parent_cache_dir, row_group_size, compression_codec):
+        meta = cls(df, row_group_size, compression_codec)
         meta.data_path = _materialize_df(
             df, parent_cache_dir, row_group_size, compression_codec)
         return meta

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -127,7 +127,6 @@ def _materialize_df(df, parent_cache_dir, row_group_size, compression_codec):
 
     df.write \
         .option("compression", compression_codec) \
-    df.write.mode("overwrite") \
         .option("parquet.block.size", row_group_size) \
         .parquet(save_to_dir)
 

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -5,6 +5,7 @@ from pyspark.sql.session import SparkSession
 import atexit
 import os
 import shutil
+import threading
 import uuid
 
 DEFAULT_CACHE_DIR = "/tmp/spark-converter"
@@ -57,18 +58,53 @@ class tf_dataset_context_manager:
         self.reader.join()
 
 
-def _cache_df_or_retrieve_cache_path(df, cache_dir, row_group_size):
+def _get_df_plan(df):
+    return df._jdf.queryExecution().analyzed()
+
+
+class CachedDataFrameMeta(object):
+
+    def __init__(self, df, parent_cache_dir, row_group_size):
+        self.row_group_size = row_group_size
+        # Note: the metadata will hold dataframe plan, but it won't
+        # hold the dataframe object (dataframe plan will not reference dataframe object),
+        # This means the dataframe can be released by spark gc.
+        self.df_plan = _get_df_plan
+        self.data_path = _materialize_df(df, parent_cache_dir, row_group_size)
+
+
+_cache_df_meta_list = []
+_cache_df_meta_list_lock = threading.Lock()
+
+
+def _cache_df_or_retrieve_cache_path(df, parent_cache_dir, row_group_size):
     """
     Check whether the df is cached.
     If so, return the existing cache file path.
     If not, cache the df into the cache_dir in parquet format and return the cache file path.
     Use atexit to delete the cache before the python interpreter exits.
-    :param df:        A :class:`DataFrame` object.
-    :param cache_dir: A string denoting the directory for the saved parquet file.
-    :return:          A string denoting the path of the saved parquet file.
+    :param df:               A :class:`DataFrame` object.
+    :param parent_cache_dir: A string denoting the directory for the saved parquet file.
+    :return:                 A string denoting the path of the saved parquet file.
     """
+    # TODO:
+    #  1. Add corrupted parquet files checking
+    #  2. Improve the global lock by fine-grained locks
+    #  3. Improve the cache list by hash table (Note we need use hash(df_plan + row_group_size)
+    with _cache_df_meta_list_lock:
+        df_plan = _get_df_plan(df)
+        for meta in _cache_df_meta_list:
+            if meta.row_group_size == row_group_size and meta.df_plan.sameResult(df_plan):
+                return meta.data_path
+        # do not find cached dataframe, start materializing.
+        cached_df_meta = CachedDataFrameMeta(df, parent_cache_dir, row_group_size)
+        _cache_df_meta_list.append(cached_df_meta)
+        return cached_df_meta.data_path
+
+
+def _materialize_df(df, parent_cache_dir, row_group_size):
     uuid_str = str(uuid.uuid4())
-    save_to_dir = os.path.join(cache_dir, uuid_str)
+    save_to_dir = os.path.join(parent_cache_dir, uuid_str)
     df.write.mode("overwrite") \
         .option("parquet.block.size", row_group_size) \
         .parquet(save_to_dir)

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -116,7 +116,7 @@ def _cache_df_or_retrieve_cache_path(df, parent_cache_dir, row_group_size, compr
                     meta.df_plan.sameResult(df_plan):
                 return meta.data_path
         # do not find cached dataframe, start materializing.
-        cached_df_meta = CachedDataFrameMeta(
+        cached_df_meta = CachedDataFrameMeta.create_cached_dataframe(
             df, parent_cache_dir, row_group_size, compression_codec)
         _cache_df_meta_list.append(cached_df_meta)
         return cached_df_meta.data_path
@@ -140,8 +140,8 @@ def _materialize_df(df, parent_cache_dir, row_group_size, compression_codec):
 def make_spark_converter(
         df,
         cache_dir=None,
-        compression=None,
-        parquet_row_group_size=ROW_GROUP_SIZE):
+        parquet_row_group_size=ROW_GROUP_SIZE,
+        compression=None):
     """
     Convert a spark dataframe into a :class:`SparkDatasetConverter` object. It will materialize
     a spark dataframe to a `cache_dir` or a default cache directory.

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -64,20 +64,21 @@ def _get_df_plan(df):
 
 class CachedDataFrameMeta(object):
 
-    def __init__(self, df, parent_cache_dir, row_group_size):
-        self.row_group_size = row_group_size
+    def __init__(self, df, parent_cache_dir, row_group_size, compression):
         # Note: the metadata will hold dataframe plan, but it won't
         # hold the dataframe object (dataframe plan will not reference dataframe object),
         # This means the dataframe can be released by spark gc.
         self.df_plan = _get_df_plan
-        self.data_path = _materialize_df(df, parent_cache_dir, row_group_size)
+        self.row_group_size = row_group_size
+        self.compression = compression
+        self.data_path = _materialize_df(df, parent_cache_dir, row_group_size, compression)
 
 
 _cache_df_meta_list = []
 _cache_df_meta_list_lock = threading.Lock()
 
 
-def _cache_df_or_retrieve_cache_path(df, parent_cache_dir, row_group_size):
+def _cache_df_or_retrieve_cache_path(df, parent_cache_dir, row_group_size, compression):
     """
     Check whether the df is cached.
     If so, return the existing cache file path.
@@ -85,26 +86,34 @@ def _cache_df_or_retrieve_cache_path(df, parent_cache_dir, row_group_size):
     Use atexit to delete the cache before the python interpreter exits.
     :param df:               A :class:`DataFrame` object.
     :param parent_cache_dir: A string denoting the directory for the saved parquet file.
+    :param compression:      Compression type for materializing dataframe
     :return:                 A string denoting the path of the saved parquet file.
     """
     # TODO:
     #  1. Add corrupted parquet files checking
     #  2. Improve the global lock by fine-grained locks
-    #  3. Improve the cache list by hash table (Note we need use hash(df_plan + row_group_size)
+    #  3. Improve the cache list by hash table:
+    #       Note we need use hash(df_plan + row_group_size + compression_type)
     with _cache_df_meta_list_lock:
         df_plan = _get_df_plan(df)
         for meta in _cache_df_meta_list:
-            if meta.row_group_size == row_group_size and meta.df_plan.sameResult(df_plan):
+            if meta.row_group_size == row_group_size and \
+                    meta.df_plan.sameResult(df_plan) and \
+                    meta.compression == compression:
                 return meta.data_path
         # do not find cached dataframe, start materializing.
-        cached_df_meta = CachedDataFrameMeta(df, parent_cache_dir, row_group_size)
+        cached_df_meta = CachedDataFrameMeta(
+            df, parent_cache_dir, row_group_size, compression)
         _cache_df_meta_list.append(cached_df_meta)
         return cached_df_meta.data_path
 
 
-def _materialize_df(df, parent_cache_dir, row_group_size):
+def _materialize_df(df, parent_cache_dir, row_group_size, compression):
     uuid_str = str(uuid.uuid4())
     save_to_dir = os.path.join(parent_cache_dir, uuid_str)
+
+    SparkSession.builder.getOrCreate().conf.set(
+        "spark.sql.parquet.compression.codec", compression)
     df.write.mode("overwrite") \
         .option("parquet.block.size", row_group_size) \
         .parquet(save_to_dir)
@@ -117,7 +126,11 @@ def _materialize_df(df, parent_cache_dir, row_group_size):
     return save_to_dir
 
 
-def make_spark_converter(df, cache_dir=None, row_group_size=ROW_GROUP_SIZE):
+def make_spark_converter(
+        df,
+        cache_dir=None,
+        compression=None,
+        parquet_row_group_size=ROW_GROUP_SIZE):
     """
     Convert a spark dataframe into a :class:`SparkDatasetConverter` object. It will materialize
     a spark dataframe to a `cache_dir` or a default cache directory.
@@ -129,7 +142,9 @@ def make_spark_converter(df, cache_dir=None, row_group_size=ROW_GROUP_SIZE):
                       Default None, it will fallback to the spark config
                       "spark.petastorm.converter.default.cache.dir".
                       If the spark config is empty, it will fallback to DEFAULT_CACHE_DIR.
-    :param row_group_size: An int denoting the number of bytes in a parquet row group.
+    :param compression: Specify compression type. Default None.
+                      If None, will automatically choose the best way.
+    :param parquet_row_group_size: An int denoting the number of bytes in a parquet row group.
 
     :return: a :class:`SparkDatasetConverter` object that holds the materialized dataframe and
             can be used to make one or more tensorflow datasets or torch dataloaders.
@@ -138,6 +153,13 @@ def make_spark_converter(df, cache_dir=None, row_group_size=ROW_GROUP_SIZE):
     if cache_dir is None:
         cache_dir = spark.conf \
             .get("spark.petastorm.converter.default.cache.dir", DEFAULT_CACHE_DIR)
-    cache_file_path = _cache_df_or_retrieve_cache_path(df, cache_dir, row_group_size)
+
+    if compression is None:
+        # TODO: Improve default behavior to be automatically choosing the best way.
+        compression = "uncompressed"
+
+    cache_file_path = _cache_df_or_retrieve_cache_path(
+        df, cache_dir, parquet_row_group_size, compression)
     dataset_size = spark.read.parquet(cache_file_path).count()
+
     return SparkDatasetConverter(cache_file_path, dataset_size)

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -74,7 +74,7 @@ def _get_df_plan(df):
 
 class CachedDataFrameMeta(object):
 
-    def __init__(self, df, parent_cache_dir, row_group_size, compression_codec):
+    def __init__(self, df, row_group_size, compression_codec):
         self.row_group_size = row_group_size
         self.compression_codec = compression_codec
         # Note: the metadata will hold dataframe plan, but it won't
@@ -85,7 +85,7 @@ class CachedDataFrameMeta(object):
 
     @classmethod
     def create_cached_dataframe(df, parent_cache_dir, row_group_size, compression_codec):
-        meta = CachedDataFrameMeta(df, parent_cache_dir, row_group_size, compression_codec)
+        meta = CachedDataFrameMeta(df, row_group_size, compression_codec)
         meta.data_path = _materialize_df(
             df, parent_cache_dir, row_group_size, compression_codec)
         return meta

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -81,9 +81,14 @@ class CachedDataFrameMeta(object):
         # hold the dataframe object (dataframe plan will not reference dataframe object),
         # This means the dataframe can be released by spark gc.
         self.df_plan = _get_df_plan(df)
-        self.data_path = _materialize_df(
-            df, parent_cache_dir, row_group_size, compression_codec)
+        self.data_path = None
 
+    @classmethod
+    def create_cached_dataframe(df, parent_cache_dir, row_group_size, compression_codec):
+        meta = CachedDataFrameMeta(df, parent_cache_dir, row_group_size, compression_codec)
+        meta.data_path = _materialize_df(
+            df, parent_cache_dir, row_group_size, compression_codec)
+        return meta
 
 _cache_df_meta_list = []
 _cache_df_meta_list_lock = threading.Lock()

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -90,6 +90,7 @@ class CachedDataFrameMeta(object):
             df, parent_cache_dir, row_group_size, compression_codec)
         return meta
 
+
 _cache_df_meta_list = []
 _cache_df_meta_list_lock = threading.Lock()
 

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -126,3 +126,23 @@ class TfConverterTest(unittest.TestCase):
         converter2 = make_spark_converter(df1, compression=True)
         self.assertEqual("snappy",
                          self._get_compression_type(converter2.cache_file_path).lower())
+
+    def test_df_caching(self):
+        df1 = self.spark.range(10)
+        df2 = self.spark.range(10)
+        df3 = self.spark.range(20)
+
+        converter1 = make_spark_converter(df1)
+        converter2 = make_spark_converter(df2)
+        self.assertEqual(converter1.cache_file_path, converter2.cache_file_path)
+
+        converter3 = make_spark_converter(df3)
+        self.assertNotEqual(converter1.cache_file_path, converter3.cache_file_path)
+
+        converter11 = make_spark_converter(df1, parquet_row_group_size=8 * 1024 * 1024)
+        converter21 = make_spark_converter(df1, parquet_row_group_size=16 * 1024 * 1024)
+        self.assertNotEqual(converter11.cache_file_path, converter21.cache_file_path)
+
+        converter12 = make_spark_converter(df1, compression=True)
+        converter22 = make_spark_converter(df1, compression=False)
+        self.assertNotEqual(converter12.cache_file_path, converter22.cache_file_path)


### PR DESCRIPTION
## Implementation:

The caching list contains `CachedDataFrameMeta` object, each CachedDataFrameMeta will hold:
* dataframe plan `df._jdf.queryExecution().analyzed()`
* row_group_size
* compression type
* data_path: the parquets file path dataframe materialized to.

When we need make a converter from a dataframe, check the caching list, if we found one `CachedDataFrameMeta` object match current dataframe plan and required row_group_size and compression type, return the data_path, otherwise materialize the dataframe, and create a new `CachedDataFrameMeta` object and insert into the caching list.

## Test
Unit test.

