### PR TITLE
[ML-9743] make_spark_converter() uses delta if it is available

### DIFF
--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -127,6 +127,12 @@ class _tf_dataset_context_manager(object):
         """
         from petastorm.tf_utils import make_petastorm_dataset
 
+        if _cache_format == "delta":
+            # TODO use spark.read.format("delta").load("....").inputFiles to get
+            # a list of input files directly to avoid S3 eventual consistency
+            # issue after make_batch_reader() can take a list of files.
+            pass
+        
         self.reader = make_batch_reader(data_url)
         self.dataset = make_petastorm_dataset(self.reader)
 

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -132,7 +132,7 @@ class _tf_dataset_context_manager(object):
             # a list of input files directly to avoid S3 eventual consistency
             # issue after make_batch_reader() can take a list of files.
             pass
-        
+
         self.reader = make_batch_reader(data_url)
         self.dataset = make_petastorm_dataset(self.reader)
 

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -249,7 +249,7 @@ class TfConverterTestOnDelta(TfConverterTest):
         cls.spark = SparkSession.builder \
             .master("local[2]") \
             .appName("petastorm.spark delta tests") \
-            .conf("spark.jars.packages", "io.delta:delta-core_2.11:0.5.0") \
+            .config("spark.jars.packages", "io.delta:delta-core_2.11:0.5.0") \
             .getOrCreate()
         cls.spark.conf.set("petastorm.spark.converter.defaultCacheDirUrl",
                            "file:///tmp/123")

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -35,9 +35,6 @@ class TfConverterTest(unittest.TestCase):
         """Child classes must override this method and define cls.spark"""
         raise unittest.SkipTest
 
-    def tearDown(self):
-        self.spark.stop()
-
     def test_primitive(self):
         schema = StructType([
             StructField("bool_col", BooleanType(), False),
@@ -257,6 +254,10 @@ class TfConverterTestOnDelta(TfConverterTest):
         cls.spark.conf.set("petastorm.spark.converter.defaultCacheDirUrl",
                            "file:///tmp/123")
 
+    @classmethod
+    def tearDownClass(cls):
+        cls.spark.stop()
+
 
 class TfConverterTestOnParquet(TfConverterTest):
     @classmethod
@@ -267,3 +268,7 @@ class TfConverterTestOnParquet(TfConverterTest):
             .getOrCreate()
         cls.spark.conf.set("petastorm.spark.converter.defaultCacheDirUrl",
                            "file:///tmp/123")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.spark.stop()


### PR DESCRIPTION
### What changes are proposed in this PR?
Check if the delta lake is available. If so, use delta as the saving format. If not, show a warning that recommends using delta to avoid S3 eventual consistency delay.

- [x] Check the availability of delta.

Won't dos:
- Provide a function to enable delta.  (Won't do: Users should setup by themselves.)
- Add a private util function that reads the _delta_log entry to get a list of saved parquet files.  (use `spark.read.format("delta").load("....").inputFiles`)
- Modify petastorm `make_batch_reader` to accept a list of files. (Will do in a separate PR)

### Why are those changes needed?
Using delta to avoid S3 eventual consistency delay.

### How is this feature tested?
Use two subclasses.
```
class TfConverterTest(unittest.TestCase):
... unittest.SkipTest

class TfConverterTestOnDelta(TfConverterTest):
...
class TfConverterTestOnParquet(TfConverterTest):
...
```