### PR TITLE
Always respect private cache dir, and refactor some var names

### DIFF
--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -150,19 +150,19 @@ def _normalize_dir_url(dir_url):
     return new_parsed.geturl()
 
 
-def _is_sub_url(url1, url2):
+def _is_sub_dir_url(dir_url1, dir_url2):
     """
     Check whether url1 is a sub directory of url2
     """
+    url1 = _normalize_dir_url(dir_url1)
+    url2 = _normalize_dir_url(dir_url2)
+
     parsed1 = urlparse(url1)
     parsed2 = urlparse(url2)
 
-    path1 = _normalize_dir_url(parsed1.path)
-    path2 = _normalize_dir_url(parsed2.path)
-
     return parsed1.scheme == parsed2.scheme and \
         parsed1.netloc == parsed2.netloc and \
-        path1.startswith(path2 + os.sep)
+        parsed1.path.startswith(parsed2.path + os.sep)
 
 
 def _cache_df_or_retrieve_cache_data_url(df, parent_cache_dir_url,
@@ -191,7 +191,7 @@ def _cache_df_or_retrieve_cache_data_url(df, parent_cache_dir_url,
             if meta.row_group_size == parquet_row_group_size_bytes and \
                     meta.compression_codec == compression_codec and \
                     meta.df_plan.sameResult(df_plan) and \
-                    _is_sub_url(meta.cache_dir_url, parent_cache_dir_url):
+                    _is_sub_dir_url(meta.cache_dir_url, parent_cache_dir_url):
                 return meta.cache_dir_url
         # do not find cached dataframe, start materializing.
         cached_df_meta = CachedDataFrameMeta.create_cached_dataframe(

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -135,6 +135,18 @@ _cache_df_meta_list = []
 _cache_df_meta_list_lock = threading.Lock()
 
 
+def _is_sub_path(url1, url2):
+    """
+    Check whether url1 is a sub path of url2
+    """
+    parsed1 = urlparse(url1)
+    parsed2 = urlparse(url2)
+
+    return parsed1.scheme == parsed2.scheme and \
+        parsed1.netloc == parsed2.netloc and \
+        parsed1.path.rstrip('/').startswith(parsed2.path.rstrip('/'))
+
+
 def _cache_df_or_retrieve_cache_data_url(df, parent_cache_dir_url,
                                          parquet_row_group_size_bytes,
                                          compression_codec):
@@ -234,7 +246,7 @@ def make_spark_converter(
     else:
         compression_codec = "uncompressed"
 
-    cache_data_url = _cache_df_or_retrieve_cache_data_url(
+    dataset_cache_dir_url = _cache_df_or_retrieve_cache_data_url(
         df, cache_dir_url, parquet_row_group_size_bytes, compression_codec)
-    dataset_size = _get_spark_session().read.parquet(cache_data_url).count()
-    return SparkDatasetConverter(cache_data_url, dataset_size)
+    dataset_size = _get_spark_session().read.parquet(dataset_cache_dir_url).count()
+    return SparkDatasetConverter(dataset_cache_dir_url, dataset_size)

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -101,7 +101,7 @@ class TfConverterTest(unittest.TestCase):
         df = self.spark.createDataFrame([(1, 2), (4, 5)], ["col1", "col2"])
         # TODO add test for hdfs url
         converter = make_spark_converter(df, 'file:///tmp/123')
-        local_path = urlparse(converter.cache_file_path).path
+        local_path = urlparse(converter.cache_dir_url).path
         self.assertTrue(os.path.exists(local_path))
         converter.delete()
         self.assertFalse(os.path.exists(local_path))
@@ -117,7 +117,7 @@ class TfConverterTest(unittest.TestCase):
         df = spark.createDataFrame([(1, 2),(4, 5)], ["col1", "col2"])
         converter = make_spark_converter(df, 'file:///tmp/spark_converter_test_atexit')
         f = open("/tmp/spark_converter_test_atexit/output", "w")
-        f.write(converter.cache_file_path)
+        f.write(converter.cache_dir_url)
         f.close()
         """
         code_str = "; ".join(
@@ -126,8 +126,8 @@ class TfConverterTest(unittest.TestCase):
         ret_code = subprocess.call(["python", "-c", code_str])
         self.assertEqual(0, ret_code)
         with open(os.path.join(cache_dir, "output")) as f:
-            cache_file_path = f.read()
-        self.assertFalse(os.path.exists(cache_file_path))
+            cache_dir_url = f.read()
+        self.assertFalse(os.path.exists(cache_dir_url))
 
     @staticmethod
     def _get_compression_type(data_url):
@@ -145,17 +145,17 @@ class TfConverterTest(unittest.TestCase):
         converter1 = make_spark_converter(df1)
         self.assertEqual("uncompressed",
                          self._get_compression_type(
-                             converter1.cache_file_path).lower())
+                             converter1.cache_dir_url).lower())
 
         converter2 = make_spark_converter(df1, compression=False)
         self.assertEqual("uncompressed",
                          self._get_compression_type(
-                             converter2.cache_file_path).lower())
+                             converter2.cache_dir_url).lower())
 
         converter2 = make_spark_converter(df1, compression=True)
         self.assertEqual("snappy",
                          self._get_compression_type(
-                             converter2.cache_file_path).lower())
+                             converter2.cache_dir_url).lower())
 
     def test_df_caching(self):
         df1 = self.spark.range(10)
@@ -164,23 +164,23 @@ class TfConverterTest(unittest.TestCase):
 
         converter1 = make_spark_converter(df1)
         converter2 = make_spark_converter(df2)
-        self.assertEqual(converter1.cache_file_path, converter2.cache_file_path)
+        self.assertEqual(converter1.cache_dir_url, converter2.cache_dir_url)
 
         converter3 = make_spark_converter(df3)
-        self.assertNotEqual(converter1.cache_file_path,
-                            converter3.cache_file_path)
+        self.assertNotEqual(converter1.cache_dir_url,
+                            converter3.cache_dir_url)
 
         converter11 = make_spark_converter(
             df1, parquet_row_group_size_bytes=8 * 1024 * 1024)
         converter21 = make_spark_converter(
             df1, parquet_row_group_size_bytes=16 * 1024 * 1024)
-        self.assertNotEqual(converter11.cache_file_path,
-                            converter21.cache_file_path)
+        self.assertNotEqual(converter11.cache_dir_url,
+                            converter21.cache_dir_url)
 
         converter12 = make_spark_converter(df1, compression=True)
         converter22 = make_spark_converter(df1, compression=False)
-        self.assertNotEqual(converter12.cache_file_path,
-                            converter22.cache_file_path)
+        self.assertNotEqual(converter12.cache_dir_url,
+                            converter22.cache_dir_url)
 
     def test_scheme(self):
         url1 = "/tmp/abc"

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -25,7 +25,7 @@ from pyspark.sql.types import (BinaryType, BooleanType, ByteType, DoubleType,
 from six.moves.urllib.parse import urlparse
 
 from petastorm import make_spark_converter
-from petastorm.spark.spark_dataset_converter import _normalize_dir_url, _is_sub_url
+from petastorm.spark.spark_dataset_converter import _normalize_dir_url, _is_sub_dir_url
 
 
 class TfConverterTest(unittest.TestCase):
@@ -188,19 +188,19 @@ class TfConverterTest(unittest.TestCase):
             _normalize_dir_url('/a/b/c')
         self.assertTrue('scheme-less' in str(cm.exception))
 
-        self.assertEqual(_normalize_dir_url('file:///a/b'), 'file:///a/b/')
-        self.assertEqual(_normalize_dir_url('file:///a//b'), 'file:///a/b/')
+        self.assertEqual(_normalize_dir_url('file:///a/b'), 'file:///a/b')
+        self.assertEqual(_normalize_dir_url('file:///a//b'), 'file:///a/b')
 
     def test_df_private_caching(self):
-        self.assertTrue(_is_sub_url('file:///a/b/c/d', 'file:///a/b/c'))
-        self.assertTrue(_is_sub_url('hdfs:///a/b/c/d', 'hdfs:///a/b/c'))
-        self.assertTrue(_is_sub_url('hdfs://nn1:9000/a/b/c/d', 'hdfs://nn1:9000/a/b/c'))
+        self.assertTrue(_is_sub_dir_url('file:///a/b/c/d', 'file:///a/b/c'))
+        self.assertTrue(_is_sub_dir_url('hdfs:///a/b/c/d', 'hdfs:///a/b/c'))
+        self.assertTrue(_is_sub_dir_url('hdfs://nn1:9000/a/b/c/d', 'hdfs://nn1:9000/a/b/c'))
 
-        self.assertFalse(_is_sub_url('file:///a/b/c', 'file:///a/b/c'))
-        self.assertFalse(_is_sub_url('file:///a/b/c/d', 'file:///a/b/cc'))
-        self.assertFalse(_is_sub_url('file:///a/b/c', 'file:///a/b/c/d'))
-        self.assertFalse(_is_sub_url('file:///a/b/c', 'hdfs:///a/b/c'))
-        self.assertFalse(_is_sub_url('hdfs://nn1:9000/a/b/c/d', 'hdfs://nn1:9001/a/b/c'))
+        self.assertFalse(_is_sub_dir_url('file:///a/b/c', 'file:///a/b/c'))
+        self.assertFalse(_is_sub_dir_url('file:///a/b/c/d', 'file:///a/b/cc'))
+        self.assertFalse(_is_sub_dir_url('file:///a/b/c', 'file:///a/b/c/d'))
+        self.assertFalse(_is_sub_dir_url('file:///a/b/c', 'hdfs:///a/b/c'))
+        self.assertFalse(_is_sub_dir_url('hdfs://nn1:9000/a/b/c/d', 'hdfs://nn1:9001/a/b/c'))
 
         df1 = self.spark.range(10)
         df2 = self.spark.range(10)

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -25,7 +25,7 @@ from pyspark.sql.types import (BinaryType, BooleanType, ByteType, DoubleType,
 from six.moves.urllib.parse import urlparse
 
 from petastorm import make_spark_converter
-from petastorm.spark.spark_dataset_converter import _normalize_dir_url, _is_same_or_sub_url
+from petastorm.spark.spark_dataset_converter import _normalize_dir_url, _is_sub_url
 
 
 class TfConverterTest(unittest.TestCase):
@@ -192,15 +192,15 @@ class TfConverterTest(unittest.TestCase):
         self.assertEqual(_normalize_dir_url('file:///a//b'), 'file:///a/b/')
 
     def test_df_private_caching(self):
-        self.assertTrue(_is_same_or_sub_url('file:///a/b/c/d', 'file:///a/b/c'))
-        self.assertTrue(_is_same_or_sub_url('hdfs:///a/b/c/d', 'hdfs:///a/b/c'))
-        self.assertTrue(_is_same_or_sub_url('hdfs://nn1:9000/a/b/c/d', 'hdfs://nn1:9000/a/b/c'))
-        self.assertTrue(_is_same_or_sub_url('file:///a/b/c', 'file:///a/b/c'))
+        self.assertTrue(_is_sub_url('file:///a/b/c/d', 'file:///a/b/c'))
+        self.assertTrue(_is_sub_url('hdfs:///a/b/c/d', 'hdfs:///a/b/c'))
+        self.assertTrue(_is_sub_url('hdfs://nn1:9000/a/b/c/d', 'hdfs://nn1:9000/a/b/c'))
 
-        self.assertFalse(_is_same_or_sub_url('file:///a/b/c/d', 'file:///a/b/cc'))
-        self.assertFalse(_is_same_or_sub_url('file:///a/b/c', 'file:///a/b/c/d'))
-        self.assertFalse(_is_same_or_sub_url('file:///a/b/c', 'hdfs:///a/b/c'))
-        self.assertFalse(_is_same_or_sub_url('hdfs://nn1:9000/a/b/c/d', 'hdfs://nn1:9001/a/b/c'))
+        self.assertFalse(_is_sub_url('file:///a/b/c', 'file:///a/b/c'))
+        self.assertFalse(_is_sub_url('file:///a/b/c/d', 'file:///a/b/cc'))
+        self.assertFalse(_is_sub_url('file:///a/b/c', 'file:///a/b/c/d'))
+        self.assertFalse(_is_sub_url('file:///a/b/c', 'hdfs:///a/b/c'))
+        self.assertFalse(_is_sub_url('hdfs://nn1:9000/a/b/c/d', 'hdfs://nn1:9001/a/b/c'))
 
         df1 = self.spark.range(10)
         df2 = self.spark.range(10)


### PR DESCRIPTION
* Respect private cache dir. Add checking when reuse cache data. The rule is: when the cached dataset located inside the specified private cache dir, then reuse it, otherwise do not reuse it, instead, materialized dataframe again to the specified private cache dir.

* Refactor some var names
* add two util method `_normalize_dir_url` and `_is_sub_dir_url`, and do some refactor.