### PR TITLE
[ML-10008] make_spark_converter() takes dtype to use double -> float conversion

### DIFF
--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -21,6 +21,7 @@ import warnings
 
 from pyarrow import LocalFileSystem
 from pyspark.sql.session import SparkSession
+from pyspark.sql.types import FloatType, DoubleType
 from six.moves.urllib.parse import urlparse
 
 from petastorm import make_batch_reader
@@ -134,7 +135,7 @@ def _get_df_plan(df):
 
 class CachedDataFrameMeta(object):
 
-    def __init__(self, df, row_group_size, compression_codec):
+    def __init__(self, df, row_group_size, compression_codec, precision):
         self.row_group_size = row_group_size
         self.compression_codec = compression_codec
         # Note: the metadata will hold dataframe plan, but it won't
@@ -143,13 +144,15 @@ class CachedDataFrameMeta(object):
         # This means the dataframe can be released by spark gc.
         self.df_plan = _get_df_plan(df)
         self.cache_dir_url = None
+        self.precision = precision
 
     @classmethod
     def create_cached_dataframe(cls, df, parent_cache_dir_url, row_group_size,
-                                compression_codec):
-        meta = cls(df, row_group_size, compression_codec)
+                                compression_codec, precision):
+        meta = cls(df, row_group_size, compression_codec, precision)
         meta.cache_dir_url = _materialize_df(
-            df, parent_cache_dir_url, row_group_size, compression_codec)
+            df, parent_cache_dir_url, row_group_size, compression_codec,
+            precision)
         return meta
 
 
@@ -187,9 +190,9 @@ def _is_sub_dir_url(dir_url1, dir_url2):
         parsed1.path.startswith(parsed2.path + os.sep)
 
 
-def _cache_df_or_retrieve_cache_data_url(df, parent_cache_dir_url,
-                                         parquet_row_group_size_bytes,
-                                         compression_codec):
+def _cache_df_or_retrieve_cache_data_url(
+        df, parent_cache_dir_url, parquet_row_group_size_bytes,
+        compression_codec, precision):
     """
     Check whether the df is cached.
     If so, return the existing cache file path.
@@ -202,6 +205,8 @@ def _cache_df_or_retrieve_cache_data_url(df, parent_cache_dir_url,
     :param parquet_row_group_size_bytes: An int denoting the number of bytes
         in a parquet row group.
     :param compression_codec: Specify compression codec.
+    :param precision: 'float32' or 'float64', specifying the precision of the
+        output dataset.
     :return: A string denoting the path of the saved parquet file.
     """
     # TODO
@@ -213,20 +218,37 @@ def _cache_df_or_retrieve_cache_data_url(df, parent_cache_dir_url,
             if meta.row_group_size == parquet_row_group_size_bytes and \
                     meta.compression_codec == compression_codec and \
                     meta.df_plan.sameResult(df_plan) and \
-                    _is_sub_dir_url(meta.cache_dir_url, parent_cache_dir_url):
+                    _is_sub_dir_url(meta.cache_dir_url, parent_cache_dir_url) \
+                    and meta.precision == precision:
                 return meta.cache_dir_url
         # do not find cached dataframe, start materializing.
         cached_df_meta = CachedDataFrameMeta.create_cached_dataframe(
             df, parent_cache_dir_url, parquet_row_group_size_bytes,
-            compression_codec)
+            compression_codec, precision)
         _cache_df_meta_list.append(cached_df_meta)
         return cached_df_meta.cache_dir_url
 
 
+def _convert_precision(df, precision):
+    if precision != "float32" and precision != "float64":
+        raise ValueError("precision {} is not supported. \
+            Use 'float32' or float64".format(precision))
+
+    source_type, target_type = (DoubleType, FloatType) \
+        if precision == "float32" else (FloatType, DoubleType)
+
+    for struct_field in df.schema:
+        col_name = struct_field.name
+        if isinstance(struct_field.dataType, source_type):
+            df = df.withColumn(col_name, df[col_name].cast(target_type()))
+    return df
+
+
 def _materialize_df(df, parent_cache_dir, parquet_row_group_size_bytes,
-                    compression_codec):
+                    compression_codec, precision):
     uuid_str = str(uuid.uuid4())
     save_to_dir = os.path.join(parent_cache_dir, uuid_str)
+    df = _convert_precision(df, precision)
 
     df.write \
         .option("compression", compression_codec) \
@@ -241,7 +263,8 @@ def make_spark_converter(
         df,
         cache_dir_url=None,
         parquet_row_group_size_bytes=DEFAULT_ROW_GROUP_SIZE_BYTES,
-        compression=None):
+        compression=None,
+        precision='float32'):
     """
     Convert a spark dataframe into a :class:`SparkDatasetConverter` object.
     It will materialize a spark dataframe to a `cache_dir_url`.
@@ -257,6 +280,8 @@ def make_spark_converter(
         in a parquet row group.
     :param compression: True or False, specify whether to apply compression.
         Default None. If None, it will automatically choose the best way.
+    :param precision: 'float32' or 'float64', specifying the precision of the
+        output dataset.
 
     :return: a :class:`SparkDatasetConverter` object that holds the
         materialized dataframe and can be used to make one or more tensorflow
@@ -284,6 +309,7 @@ def make_spark_converter(
         compression_codec = "uncompressed"
 
     dataset_cache_dir_url = _cache_df_or_retrieve_cache_data_url(
-        df, cache_dir_url, parquet_row_group_size_bytes, compression_codec)
+        df, cache_dir_url, parquet_row_group_size_bytes, compression_codec,
+        precision)
     dataset_size = _get_spark_session().read.parquet(dataset_cache_dir_url).count()
     return SparkDatasetConverter(dataset_cache_dir_url, dataset_size)

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -77,7 +77,13 @@ class TfConverterTest(unittest.TestCase):
                         actual_ele = actual_ele.decode()
                     if col == "bin_col":
                         actual_ele = bytearray(actual_ele)
-                    self.assertEqual(expected_ele, actual_ele)
+
+                    if col == "float_col":
+                        self.assertAlmostEqual(expected_ele, actual_ele, places=7)
+                    elif col == "double_col":
+                        self.assertAlmostEqual(expected_ele, actual_ele, places=15)
+                    else:
+                        self.assertEqual(expected_ele, actual_ele)
 
             self.assertEqual(len(expected_df), len(converter))
 

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -78,10 +78,9 @@ class TfConverterTest(unittest.TestCase):
                     if col == "bin_col":
                         actual_ele = bytearray(actual_ele)
 
-                    if col == "float_col":
+                    if col == "float_col" or col == "double_col":
+                        # Note that the default precision is float32
                         self.assertAlmostEqual(expected_ele, actual_ele, places=7)
-                    elif col == "double_col":
-                        self.assertAlmostEqual(expected_ele, actual_ele, places=15)
                     else:
                         self.assertEqual(expected_ele, actual_ele)
 

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -80,7 +80,7 @@ class TfConverterTest(unittest.TestCase):
 
                     if col == "float_col" or col == "double_col":
                         # Note that the default precision is float32
-                        self.assertAlmostEqual(expected_ele, actual_ele, places=7)
+                        self.assertAlmostEqual(expected_ele, actual_ele, places=6)
                     else:
                         self.assertEqual(expected_ele, actual_ele)
 

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -267,16 +267,14 @@ class TfConverterTest(unittest.TestCase):
         df1 = self.spark.createDataFrame(
             [([1., 2., 3., 4., 5., 6.],),
              ([4., 5., 6., 7., 8., 9.],)],
-            StructType(
-                [StructField(name='c1', dataType=ArrayType(DoubleType()))]))
+            StructType([StructField(name='c1', dataType=ArrayType(DoubleType()))]))
 
         converter1 = make_spark_converter(df1)
 
         def preproc_fn(x):
             return tf.reshape(x.c1, [-1, 3, 2]),
 
-        with converter1.make_tf_dataset(batch_size=2,
-                                        preproc_fn=preproc_fn) as dataset:
+        with converter1.make_tf_dataset(batch_size=2, preproc_fn=preproc_fn) as dataset:
             iterator = dataset.make_one_shot_iterator()
             tensor = iterator.get_next()
             with tf.Session() as sess:

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -80,7 +80,7 @@ class TfConverterTest(unittest.TestCase):
 
                     if col == "float_col" or col == "double_col":
                         # Note that the default precision is float32
-                        self.assertAlmostEqual(expected_ele, actual_ele, places=6)
+                        self.assertAlmostEqual(expected_ele, actual_ele, places=4)
                     else:
                         self.assertEqual(expected_ele, actual_ele)
 
@@ -90,7 +90,8 @@ class TfConverterTest(unittest.TestCase):
                          "Boolean type column is not inferred correctly.")
         self.assertEqual(np.float32, ts.float_col.dtype.type,
                          "Float type column is not inferred correctly.")
-        self.assertEqual(np.float64, ts.double_col.dtype.type,
+        # Default precision float32
+        self.assertEqual(np.float32, ts.double_col.dtype.type,
                          "Double type column is not inferred correctly.")
         self.assertEqual(np.int16, ts.short_col.dtype.type,
                          "Short type column is not inferred correctly.")


### PR DESCRIPTION
* Add param `precision` to `make_spark_converter()`, converting floating-point type to the desired precision at saving time.
* Tested in a unit test.
* Latest API: 
```
make_spark_converter(
        df,
        cache_dir_url=None,
        parquet_row_group_size_bytes=DEFAULT_ROW_GROUP_SIZE_BYTES,
        compression=None,
        precision='float32')
```