### PR TITLE
[ML-9745] make_spark_converter() converts MLlib vectors into dense arrays

### DIFF
--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -13,18 +13,17 @@
 # limitations under the License.
 
 import atexit
+import datetime
+import logging
 import shutil
 import threading
-import datetime
 import uuid
-import logging
 import warnings
-
 from distutils.version import LooseVersion
 
 from pyarrow import LocalFileSystem
 from pyspark.sql.session import SparkSession
-from pyspark.sql.types import FloatType, DoubleType, ArrayType
+from pyspark.sql.types import ArrayType, DoubleType, FloatType
 from six.moves.urllib.parse import urlparse
 
 from petastorm import make_batch_reader
@@ -401,7 +400,7 @@ def _convert_vector(df, precision):
         return df
 
     import pyspark
-    if pyspark.__version__ < "3.0.0":
+    if LooseVersion(pyspark.__version__) >= LooseVersion('3.0'):
         raise ValueError("Vector columns are not supported for pyspark<3.0.0.")
     # pylint: disable=import-error
     from pyspark.ml.functions import vector_to_array

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -391,10 +391,35 @@ def _gen_cache_dir_name():
     return '{time}-appid-{appid}-{uuid}'.format(time=time_str, appid=appid, uuid=uuid_str)
 
 
+def _convert_vector(df, precision):
+    from pyspark.ml.linalg import Vector
+    from pyspark.mllib.linalg import Vector as OldVector
+
+    types_set = {struct_field.dataType for struct_field in df.schema}
+    found_vectors = not types_set.isdisjoint({Vector, OldVector})
+    if not found_vectors:
+        return df
+
+    import pyspark
+    if pyspark.__version__ < "3.0.0":
+        raise ValueError("Vector columns are not supported for pyspark<3.0.0.")
+    # pylint: disable=import-error
+    from pyspark.ml.functions import vector_to_array
+    # pylint: enable=import-error
+
+    for struct_field in df.schema:
+        col_name = struct_field.name
+        if struct_field.dataType in {Vector, OldVector}:
+            df = df.withColumn(col_name,
+                               vector_to_array(df[col_name], precision))
+    return df
+
+
 def _materialize_df(df, parent_cache_dir_url, parquet_row_group_size_bytes,
                     compression_codec, precision):
     dir_name = _gen_cache_dir_name()
     save_to_dir_url = _make_sub_dir_url(parent_cache_dir_url, dir_name)
+    df = _convert_vector(df, precision)
     df = _convert_precision(df, precision)
 
     df.write \

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -326,14 +326,14 @@ def test_vector_to_array(test_ctx):
     pytest.mark.skipif(
         pyspark.__version__ < "3.0.0",
         reason="Vector columns are not supported for pyspark {} < 3.0.0"
-               .format(pyspark.__version__))
+        .format(pyspark.__version__))
 
     from pyspark.ml.linalg import Vectors
     from pyspark.mllib.linalg import Vectors as OldVectors
     df = test_ctx.spark.createDataFrame([
         (Vectors.dense(1.0, 2.0, 3.0), OldVectors.dense(10.0, 20.0, 30.0)),
         (Vectors.dense(5.0, 6.0, 7.0), OldVectors.dense(50.0, 60.0, 70.0))],
-        ["vec", "oldVec"])
+                                        ["vec", "oldVec"])
     converter1 = make_spark_converter(df)
     with converter1.make_tf_dataset() as dataset:
         iterator = dataset.make_one_shot_iterator()

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -16,22 +16,23 @@ import os
 import subprocess
 import sys
 import tempfile
-import pytest
+from distutils.version import LooseVersion
 
 import numpy as np
 import pyspark
+import pytest
 import tensorflow as tf
 from pyspark.sql import SparkSession
-from pyspark.sql.types import (ArrayType, BinaryType, BooleanType, ByteType, DoubleType,
-                               FloatType, IntegerType, LongType, ShortType,
-                               StringType, StructField, StructType)
+from pyspark.sql.types import (ArrayType, BinaryType, BooleanType, ByteType,
+                               DoubleType, FloatType, IntegerType, LongType,
+                               ShortType, StringType, StructField, StructType)
 from six.moves.urllib.parse import urlparse
 
 from petastorm.fs_utils import FilesystemResolver
-from petastorm.spark import make_spark_converter
-from petastorm.spark import spark_dataset_converter
-from petastorm.spark.spark_dataset_converter import register_delete_dir_handler, \
-    _check_url, _get_parent_cache_dir_url, _make_sub_dir_url
+from petastorm.spark import make_spark_converter, spark_dataset_converter
+from petastorm.spark.spark_dataset_converter import (
+    _check_url, _get_parent_cache_dir_url, _make_sub_dir_url,
+    register_delete_dir_handler)
 
 
 class TestContext(object):
@@ -323,7 +324,7 @@ def test_array(test_ctx):
 
 
 @pytest.mark.skipif(
-    pyspark.__version__ < "3.0.0",
+    LooseVersion(pyspark.__version__) < LooseVersion("3.0"),
     reason="Vector columns are not supported for pyspark {} < 3.0.0"
     .format(pyspark.__version__))
 def test_vector_to_array(test_ctx):
@@ -343,6 +344,8 @@ def test_vector_to_array(test_ctx):
     assert np.float32 == ts.oldVec.dtype.type
     assert (2, 3) == ts.vec.shape
     assert (2, 3) == ts.oldVec.shape
+    assert [[1., 2., 3.], [5., 6., 7.]] == ts.vec
+    assert [[10., 20., 30.], [50., 60., 70]] == ts.oldVec
 
 
 def test_torch_primitive(test_ctx):

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -19,6 +19,7 @@ import tempfile
 import pytest
 
 import numpy as np
+import pyspark
 import tensorflow as tf
 from pyspark.sql import SparkSession
 from pyspark.sql.types import (ArrayType, BinaryType, BooleanType, ByteType, DoubleType,
@@ -321,13 +322,11 @@ def test_array(test_ctx):
     assert np.float32 == ts.c1.dtype.type
 
 
+@pytest.mark.skipif(
+    pyspark.__version__ < "3.0.0",
+    reason="Vector columns are not supported for pyspark {} < 3.0.0"
+    .format(pyspark.__version__))
 def test_vector_to_array(test_ctx):
-    import pyspark
-    pytest.mark.skipif(
-        pyspark.__version__ < "3.0.0",
-        reason="Vector columns are not supported for pyspark {} < 3.0.0"
-        .format(pyspark.__version__))
-
     from pyspark.ml.linalg import Vectors
     from pyspark.mllib.linalg import Vectors as OldVectors
     df = test_ctx.spark.createDataFrame([


### PR DESCRIPTION
Tests will be added when pyspark 3.0.0 is released.