### PR TITLE
[ML-9749] make_torch_dataloader() takes advanced params

### DIFF
--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -29,7 +29,6 @@ from six.moves.urllib.parse import urlparse
 
 from petastorm import make_batch_reader
 from petastorm.fs_utils import FilesystemResolver
-from petastorm.transform import TransformSpec
 
 DEFAULT_ROW_GROUP_SIZE_BYTES = 32 * 1024 * 1024
 

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -29,6 +29,7 @@ from six.moves.urllib.parse import urlparse
 
 from petastorm import make_batch_reader
 from petastorm.fs_utils import FilesystemResolver
+from petastorm.transform import TransformSpec
 
 DEFAULT_ROW_GROUP_SIZE_BYTES = 32 * 1024 * 1024
 
@@ -172,7 +173,14 @@ class SparkDatasetConverter(object):
             preproc_parallelism=preproc_parallelism
         )
 
-    def make_torch_dataloader(self):
+    def make_torch_dataloader(self,
+                              batch_size=32,
+                              num_epochs=None,
+                              workers_count=None,
+                              cur_shard=None,
+                              shard_count=None,
+                              preprocess_pandas_fn=None,
+                              **petastorm_reader_kwargs):
         """
         Make a PyTorch DataLoader.
 
@@ -180,11 +188,38 @@ class SparkDatasetConverter(object):
           1) Open a petastorm reader on the materialized dataset dir.
           2) Create a PyTorch DataLoader based on the reader created in (1)
 
+        :param batch_size: The number of items to return per batch
+        :param num_epochs: An epoch is a single pass over all rows in the
+            dataset. Setting ``num_epochs`` to ``None`` will result in an
+            infinite number of epochs.
+        :param workers_count: An int for the number of workers to use in the
+            reader pool. This only is used for the thread or process pool.
+            Defaults to None, which means using the default value from
+            `petastorm.make_batch_reader()`.
+        :param cur_shard: An int denoting the current shard number. Each node
+            reading a shard should pass in a unique shard number in the range
+            [0, shard_count). shard_count must be supplied as well. Defaults to
+            None
+        :param shard_count: An int denoting the number of shards to break this
+            dataset into. Defaults to None
+        :param preprocess_pandas_fn: Process one row group as a pandas
+            DataFrame/Series (single column) and return a pandas
+            DataFrame/Series
+        :param petastorm_reader_kwargs: all the arguments for
+            `petastorm.make_batch_reader()`.
+
         :return: a context manager for a `torch.utils.data.DataLoader` object.
                  when exit the returned context manager, the reader
                  will be closed.
         """
-        return TorchDatasetContextManager(self.cache_dir_url)
+        return TorchDatasetContextManager(self.cache_dir_url,
+                                          batch_size,
+                                          num_epochs,
+                                          workers_count,
+                                          cur_shard,
+                                          shard_count,
+                                          preprocess_pandas_fn,
+                                          **petastorm_reader_kwargs)
 
     def delete(self):
         """
@@ -252,14 +287,35 @@ class TorchDatasetContextManager(object):
     :class:`petastorm.Reader`.
     """
 
-    def __init__(self, data_url):
+    def __init__(self, data_url, batch_size, num_epochs, workers_count,
+                 cur_shard, shard_count, preprocess_pandas_fn,
+                 **petastorm_reader_kwargs):
         """
         :param data_url: A string specifying the data URL.
+        See `SparkDatasetConverter.make_torch_dataloader()` for the definitions
+        of the other parameters.
         """
         from petastorm.pytorch import DataLoader
 
-        self.reader = make_batch_reader(data_url)
-        self.loader = DataLoader(reader=self.reader)
+        petastorm_reader_kwargs["num_epochs"] = num_epochs
+        if workers_count is not None:
+            petastorm_reader_kwargs["workers_count"] = workers_count
+        petastorm_reader_kwargs["cur_shard"] = cur_shard
+        petastorm_reader_kwargs["shard_count"] = shard_count
+        if preprocess_pandas_fn is None:
+            # If transform_spec is provided, we respect it.
+            pass
+        elif "transform_spec" not in petastorm_reader_kwargs:
+            # If transform_spec is not provided, we use preprocess_pandas_fn.
+            transform = TransformSpec(preprocess_pandas_fn, removed_fields=[])
+            petastorm_reader_kwargs["transform_spec"] = transform
+        else:
+            # If both are provided, we respect transform_spec with a warning.
+            warnings.warn("The param `preprocess_pandas_fn` will be ignored "
+                          "when `transform_spec` is provided.")
+
+        self.reader = make_batch_reader(data_url, **petastorm_reader_kwargs)
+        self.loader = DataLoader(reader=self.reader, batch_size=batch_size)
 
     def __enter__(self):
         return self.loader

--- a/petastorm/spark/spark_dataset_converter.py
+++ b/petastorm/spark/spark_dataset_converter.py
@@ -27,7 +27,7 @@ from pyspark.sql.session import SparkSession
 from pyspark.sql.types import FloatType, DoubleType, ArrayType
 from six.moves.urllib.parse import urlparse
 
-from petastorm import make_batch_reader
+import petastorm
 from petastorm.fs_utils import FilesystemResolver
 
 DEFAULT_ROW_GROUP_SIZE_BYTES = 32 * 1024 * 1024
@@ -247,7 +247,7 @@ class TFDatasetContextManager(object):
         def support_prefetch_and_autotune():
             return LooseVersion(tf.__version__) >= LooseVersion('1.14')
 
-        self.reader = make_batch_reader(data_url)
+        self.reader = petastorm.make_batch_reader(data_url)
         self.dataset = make_petastorm_dataset(self.reader) \
             .flat_map(tf.data.Dataset.from_tensor_slices) \
 
@@ -296,7 +296,7 @@ class TorchDatasetContextManager(object):
         petastorm_reader_kwargs["cur_shard"] = cur_shard
         petastorm_reader_kwargs["shard_count"] = shard_count
 
-        self.reader = make_batch_reader(data_url, **petastorm_reader_kwargs)
+        self.reader = petastorm.make_batch_reader(data_url, **petastorm_reader_kwargs)
         self.loader = DataLoader(reader=self.reader, batch_size=batch_size)
 
     def __enter__(self):

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -406,34 +406,72 @@ def test_advanced_params(test_ctx):
     with pytest.raises(TypeError, match="unexpected keyword argument 'xyz'"):
         conv.make_torch_dataloader(xyz=1)
 
-    class ReaderMock:
-        def __init__(self, filesystem, dataset_path, schema_fields, **kwargs):
-            self.filesystem = filesystem
-            self.dataset_path = dataset_path
-            self.schema_fields = schema_fields
-            self.kwargs = kwargs
+    def mock_make_batch_reader(dataset_url,
+                               schema_fields=None,
+                               reader_pool_type='thread', workers_count=10,
+                               shuffle_row_groups=True, shuffle_row_drop_partitions=1,
+                               predicate=None,
+                               rowgroup_selector=None,
+                               num_epochs=1,
+                               cur_shard=None, shard_count=None,
+                               cache_type='null', cache_location=None, cache_size_limit=None,
+                               cache_row_size_estimate=None, cache_extra_settings=None,
+                               hdfs_driver='libhdfs3',
+                               transform_spec=None):
+        return {
+            "dataset_url": dataset_url,
+            "schema_fields": schema_fields,
+            "reader_pool_type": reader_pool_type,
+            "workers_count": workers_count,
+            "shuffle_row_groups": shuffle_row_groups,
+            "shuffle_row_drop_partitions": shuffle_row_drop_partitions,
+            "predicate": predicate,
+            "rowgroup_selector": rowgroup_selector,
+            "num_epochs": num_epochs,
+            "cur_shard": cur_shard,
+            "shard_count": shard_count,
+            "cache_type": cache_type,
+            "cache_location": cache_location,
+            "cache_size_limit": cache_size_limit,
+            "cache_row_size_estimate": cache_row_size_estimate,
+            "cache_extra_settings": cache_extra_settings,
+            "hdfs_driver": hdfs_driver,
+            "transform_spec": transform_spec,
+        }
 
-    original_reader_class = petastorm.reader.Reader
-    petastorm.reader.Reader = ReaderMock
+    original_fn = petastorm.make_batch_reader
+    petastorm.make_batch_reader = mock_make_batch_reader
     ctm = conv.make_torch_dataloader(schema_fields="schema_1",
-                                     reader_pool_type='dummy',
+                                     reader_pool_type='type_1',
+                                     workers_count="count_1",
                                      shuffle_row_groups="row_group_1",
                                      shuffle_row_drop_partitions="drop_1",
                                      predicate="predicate_1",
                                      rowgroup_selector="selector_1",
-                                     num_epochs=123,
+                                     num_epochs="num_1",
                                      cur_shard="shard_1",
                                      shard_count="total_shard",
+                                     cache_type="cache_1",
+                                     cache_location="location_1",
+                                     cache_size_limit="limit_1",
+                                     cache_extra_settings="extra_1",
+                                     hdfs_driver="driver_1",
                                      transform_spec="transform_spec_1")
-    assert ctm.reader.schema_fields == "schema_1"
-    from petastorm.workers_pool.dummy_pool import DummyPool
-    assert isinstance(ctm.reader.kwargs["reader_pool"], DummyPool)
-    assert ctm.reader.kwargs["shuffle_row_groups"] == "row_group_1"
-    assert ctm.reader.kwargs["shuffle_row_drop_partitions"] == "drop_1"
-    assert ctm.reader.kwargs["predicate"] == "predicate_1"
-    assert ctm.reader.kwargs["rowgroup_selector"] == "selector_1"
-    assert ctm.reader.kwargs["cur_shard"] == "shard_1"
-    assert ctm.reader.kwargs["shard_count"] == "total_shard"
-    assert ctm.reader.kwargs["transform_spec"] == "transform_spec_1"
+    assert ctm.reader["schema_fields"] == "schema_1"
+    assert ctm.reader["reader_pool_type"] == "type_1"
+    assert ctm.reader["workers_count"] == "count_1"
+    assert ctm.reader["shuffle_row_groups"] == "row_group_1"
+    assert ctm.reader["shuffle_row_drop_partitions"] == "drop_1"
+    assert ctm.reader["predicate"] == "predicate_1"
+    assert ctm.reader["rowgroup_selector"] == "selector_1"
+    assert ctm.reader["num_epochs"] == "num_1"
+    assert ctm.reader["cur_shard"] == "shard_1"
+    assert ctm.reader["shard_count"] == "total_shard"
+    assert ctm.reader["cache_type"] == "cache_1"
+    assert ctm.reader["cache_location"] == "location_1"
+    assert ctm.reader["cache_size_limit"] == "limit_1"
+    assert ctm.reader["cache_extra_settings"] == "extra_1"
+    assert ctm.reader["hdfs_driver"] == "driver_1"
+    assert ctm.reader["transform_spec"] == "transform_spec_1"
 
-    petastorm.reader.Reader = original_reader_class
+    petastorm.make_batch_reader = original_fn

--- a/petastorm/tests/test_spark_dataset_converter.py
+++ b/petastorm/tests/test_spark_dataset_converter.py
@@ -388,6 +388,7 @@ def test_advanced_params(test_ctx):
             assert batch_size == batch['id'].shape[0]
 
     from torchvision import transforms
+    from petastorm import TransformSpec
 
     def _transform_row(df_row):
         scale_tranform = transforms.Compose([
@@ -395,7 +396,8 @@ def test_advanced_params(test_ctx):
         ])
         return scale_tranform(df_row)
 
-    with conv.make_torch_dataloader(preprocess_pandas_fn=_transform_row,
+    transform = TransformSpec(_transform_row)
+    with conv.make_torch_dataloader(transform_spec=transform,
                                     num_epochs=1) as dataloader:
         for batch in dataloader:
             assert min(batch['id']) >= 0 and max(batch['id']) < 1


### PR DESCRIPTION
`make_torch_dataloader()` can take all the keyword params supported by `make_batch_reader()` and `DataLoader`.

Reference:
```
def make_batch_reader(dataset_url,
                      schema_fields=None,
                      reader_pool_type='thread', workers_count=10,
                      shuffle_row_groups=True, shuffle_row_drop_partitions=1,
                      predicate=None,
                      rowgroup_selector=None,
                      num_epochs=1,
                      cur_shard=None, shard_count=None,
                      cache_type='null', cache_location=None, cache_size_limit=None,
                      cache_row_size_estimate=None, cache_extra_settings=None,
                      hdfs_driver='libhdfs3',
                      transform_spec=None):
class DataLoader(object):
    def __init__(self, reader, batch_size=1, collate_fn=decimal_friendly_collate,
                 shuffling_queue_capacity=0):
```